### PR TITLE
Use default publish strategy in case it not specified

### DIFF
--- a/src/Lykke.RabbitMqBroker/Publisher/RabbitMqPublisher.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/RabbitMqPublisher.cs
@@ -73,6 +73,9 @@ namespace Lykke.RabbitMqBroker.Publisher
 
         public RabbitMqPublisher<TMessageModel> Start()
         {
+            if (_publishStrategy == null)
+                _publishStrategy = new DefaultFnoutPublishStrategy();
+            
             if (_thread == null)
             {
                 _thread = new Thread(ConnectionThread);


### PR DESCRIPTION
In current realisation it is necessary to call `SetPublishStrategy()` method, but there is a default one which is created in `Stop()` method automatically. Let's create it in `Start()` method and setting up will be easier.