### PR TITLE
Pub and sub marks were added to the client provider name to distinct …

### DIFF
--- a/src/Lykke.RabbitMqBroker/Publisher/RawMessagePublisher.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/RawMessagePublisher.cs
@@ -129,7 +129,7 @@ namespace Lykke.RabbitMqBroker.Publisher
 
             _console?.WriteLine($"{Name}: trying to connect to {_settings.ConnectionString} ({_settings.GetQueueOrExchangeName()})");
 
-            var cn = $"{PlatformServices.Default.Application.ApplicationName} {PlatformServices.Default.Application.ApplicationVersion}";
+            var cn = $"[Pub] {PlatformServices.Default.Application.ApplicationName} {PlatformServices.Default.Application.ApplicationVersion}";
             using (var connection = factory.CreateConnection(cn))
             using (var channel = connection.CreateModel())
             {

--- a/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqSubscriber.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqSubscriber.cs
@@ -148,7 +148,7 @@ namespace Lykke.RabbitMqBroker.Subscriber
             var factory = new ConnectionFactory { Uri = _settings.ConnectionString };
             _console?.WriteLine($"{_settings.GetSubscriberName()}: trying to connect to {_settings.ConnectionString} ({_settings.GetQueueOrExchangeName()})");
 
-            var cn = $"{PlatformServices.Default.Application.ApplicationName} {PlatformServices.Default.Application.ApplicationVersion}";
+            var cn = $"[Sub] {PlatformServices.Default.Application.ApplicationName} {PlatformServices.Default.Application.ApplicationVersion}";
             using (var connection = factory.CreateConnection(cn))
             using (var channel = connection.CreateModel())
             {


### PR DESCRIPTION
…publisher and subscriber connections in the RabbitMq manager