### PR TITLE
#65 missing license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Lykke Corp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/Lykke.RabbitMqBroker/AssemblyInfo.cs
+++ b/src/Lykke.RabbitMqBroker/AssemblyInfo.cs
@@ -1,3 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Lykke.RabbitMqBroker.Tests")]

--- a/src/Lykke.RabbitMqBroker/DeadQueueErrorHandlingStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/DeadQueueErrorHandlingStrategy.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Threading;
 using Common.Log;
 using JetBrains.Annotations;

--- a/src/Lykke.RabbitMqBroker/Deduplication/HashHelper.cs
+++ b/src/Lykke.RabbitMqBroker/Deduplication/HashHelper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Security.Cryptography;
 
 namespace Lykke.RabbitMqBroker.Deduplication

--- a/src/Lykke.RabbitMqBroker/Deduplication/IDeduplicator.cs
+++ b/src/Lykke.RabbitMqBroker/Deduplication/IDeduplicator.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Deduplication

--- a/src/Lykke.RabbitMqBroker/Deduplication/InMemoryDeduplcator.cs
+++ b/src/Lykke.RabbitMqBroker/Deduplication/InMemoryDeduplcator.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Text;
 using System.Threading.Tasks;
 using JetBrains.Annotations;

--- a/src/Lykke.RabbitMqBroker/DefaultErrorHandlingStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/DefaultErrorHandlingStrategy.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Threading;
 using Common.Log;
 using JetBrains.Annotations;

--- a/src/Lykke.RabbitMqBroker/DefaultStringDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/DefaultStringDeserializer.cs
@@ -1,4 +1,7 @@
-﻿using System.Text;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Text;
 using Lykke.RabbitMqBroker.Subscriber;
 
 namespace Lykke.RabbitMqBroker

--- a/src/Lykke.RabbitMqBroker/Extensions.cs
+++ b/src/Lykke.RabbitMqBroker/Extensions.cs
@@ -1,4 +1,7 @@
-﻿using Lykke.RabbitMqBroker.Subscriber;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using Lykke.RabbitMqBroker.Subscriber;
 
 namespace Lykke.RabbitMqBroker
 {

--- a/src/Lykke.RabbitMqBroker/IErrorHandlingStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/IErrorHandlingStrategy.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Threading;
 
 namespace Lykke.RabbitMqBroker

--- a/src/Lykke.RabbitMqBroker/IMessageAcceptor.cs
+++ b/src/Lykke.RabbitMqBroker/IMessageAcceptor.cs
@@ -1,4 +1,7 @@
-﻿namespace Lykke.RabbitMqBroker
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace Lykke.RabbitMqBroker
 {
     public interface IMessageAcceptor
     {

--- a/src/Lykke.RabbitMqBroker/MessageAcceptor.cs
+++ b/src/Lykke.RabbitMqBroker/MessageAcceptor.cs
@@ -1,4 +1,7 @@
-﻿using RabbitMQ.Client;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker
 {

--- a/src/Lykke.RabbitMqBroker/Publisher/DefaultFanoutPublishStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/DefaultFanoutPublishStrategy.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using Lykke.RabbitMqBroker.Subscriber;
 using RabbitMQ.Client;
 

--- a/src/Lykke.RabbitMqBroker/Publisher/DeferredMessages/DeferredMessageEnvelope.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/DeferredMessages/DeferredMessageEnvelope.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Publisher.DeferredMessages

--- a/src/Lykke.RabbitMqBroker/Publisher/DeferredMessages/DeferredMessagesManager.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/DeferredMessages/DeferredMessagesManager.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Lykke.RabbitMqBroker/Publisher/DeferredMessages/IDeferredMessagesRepository.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/DeferredMessages/IDeferredMessagesRepository.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using JetBrains.Annotations;

--- a/src/Lykke.RabbitMqBroker/Publisher/IPublisherBuffer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/IPublisherBuffer.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 

--- a/src/Lykke.RabbitMqBroker/Publisher/IPublishingQueueRepository.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/IPublishingQueueRepository.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Lykke.RabbitMqBroker.Publisher

--- a/src/Lykke.RabbitMqBroker/Publisher/IRabbitMqPublishStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/IRabbitMqPublishStrategy.cs
@@ -1,4 +1,7 @@
-﻿using Lykke.RabbitMqBroker.Subscriber;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using Lykke.RabbitMqBroker.Subscriber;
 using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Publisher

--- a/src/Lykke.RabbitMqBroker/Publisher/IRabbitMqSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/IRabbitMqSerializer.cs
@@ -1,4 +1,7 @@
-﻿namespace Lykke.RabbitMqBroker.Publisher
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+namespace Lykke.RabbitMqBroker.Publisher
 {
     public interface IRabbitMqSerializer<in TMessageModel>
     {

--- a/src/Lykke.RabbitMqBroker/Publisher/IRawMessagePublisher.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/IRawMessagePublisher.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 
 namespace Lykke.RabbitMqBroker.Publisher

--- a/src/Lykke.RabbitMqBroker/Publisher/InMemoryBuffer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/InMemoryBuffer.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/Lykke.RabbitMqBroker/Publisher/JsonMessageSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/JsonMessageSerializer.cs
@@ -1,4 +1,7 @@
-﻿using System.Text;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Text;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 

--- a/src/Lykke.RabbitMqBroker/Publisher/MessagePackMessageSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/MessagePackMessageSerializer.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.IO;
 using JetBrains.Annotations;
 using MessagePack;
 

--- a/src/Lykke.RabbitMqBroker/Publisher/ProtobufMessageSerializer.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/ProtobufMessageSerializer.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.IO;
 using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Publisher

--- a/src/Lykke.RabbitMqBroker/Publisher/RabbitMqPublisher.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/RabbitMqPublisher.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/Lykke.RabbitMqBroker/Publisher/RabbitMqPublisherQueueMonitor.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/RabbitMqPublisherQueueMonitor.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Threading.Tasks;
 using Common;
 using Common.Log;

--- a/src/Lykke.RabbitMqBroker/Publisher/RawMessage.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/RawMessage.cs
@@ -1,4 +1,7 @@
-﻿using JetBrains.Annotations;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Publisher
 {

--- a/src/Lykke.RabbitMqBroker/Publisher/RawMessagePublisher.cs
+++ b/src/Lykke.RabbitMqBroker/Publisher/RawMessagePublisher.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/Lykke.RabbitMqBroker/RabbitMqBrokerException.cs
+++ b/src/Lykke.RabbitMqBroker/RabbitMqBrokerException.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 
 namespace Lykke.RabbitMqBroker
 {

--- a/src/Lykke.RabbitMqBroker/RabbitMqSubscriptionSettings.cs
+++ b/src/Lykke.RabbitMqBroker/RabbitMqSubscriptionSettings.cs
@@ -1,4 +1,7 @@
-﻿using JetBrains.Annotations;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using JetBrains.Annotations;
 using System;
 
 namespace Lykke.RabbitMqBroker.Subscriber

--- a/src/Lykke.RabbitMqBroker/ResilientErrorHandlingStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/ResilientErrorHandlingStrategy.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Common.Log;

--- a/src/Lykke.RabbitMqBroker/Subscriber/FormatMigrationMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/FormatMigrationMessageDeserializer.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Subscriber

--- a/src/Lykke.RabbitMqBroker/Subscriber/FormatMigrationMessageDeserializerFactory.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/FormatMigrationMessageDeserializerFactory.cs
@@ -1,4 +1,7 @@
-﻿using System.Text;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Text;
 using JetBrains.Annotations;
 using MessagePack;
 using Newtonsoft.Json;

--- a/src/Lykke.RabbitMqBroker/Subscriber/IMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/IMessageDeserializer.cs
@@ -1,4 +1,7 @@
-﻿using JetBrains.Annotations;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Subscriber
 {

--- a/src/Lykke.RabbitMqBroker/Subscriber/IMessageReadStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/IMessageReadStrategy.cs
@@ -1,4 +1,7 @@
-﻿using JetBrains.Annotations;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using JetBrains.Annotations;
 using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber

--- a/src/Lykke.RabbitMqBroker/Subscriber/JsonMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/JsonMessageDeserializer.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.IO;
 using System.Text;
 using JetBrains.Annotations;
 using Newtonsoft.Json;

--- a/src/Lykke.RabbitMqBroker/Subscriber/MessagePackMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/MessagePackMessageDeserializer.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.IO;
 using JetBrains.Annotations;
 using MessagePack;
 

--- a/src/Lykke.RabbitMqBroker/Subscriber/MessageReadQueueStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/MessageReadQueueStrategy.cs
@@ -1,4 +1,7 @@
-﻿using RabbitMQ.Client;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using RabbitMQ.Client;
 
 namespace Lykke.RabbitMqBroker.Subscriber
 {

--- a/src/Lykke.RabbitMqBroker/Subscriber/MessageReadWithTemporaryQueueStrategy.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/MessageReadWithTemporaryQueueStrategy.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using RabbitMQ.Client;
 

--- a/src/Lykke.RabbitMqBroker/Subscriber/ProtobufMessageDeserializer.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/ProtobufMessageDeserializer.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.IO;
 using JetBrains.Annotations;
 
 namespace Lykke.RabbitMqBroker.Subscriber

--- a/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqSubscriber.cs
+++ b/src/Lykke.RabbitMqBroker/Subscriber/RabbitMqSubscriber.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Text;
 using System.Threading.Tasks;
 using System.Threading;

--- a/src/TestInvoke/Program.cs
+++ b/src/TestInvoke/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using Lykke.RabbitMqBroker.Subscriber;
 using TestInvoke.SubscribeExample;
 

--- a/src/TestInvoke/PublishExample/HowToPublish.cs
+++ b/src/TestInvoke/PublishExample/HowToPublish.cs
@@ -1,4 +1,7 @@
-﻿using Lykke.RabbitMqBroker.Publisher;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using Lykke.RabbitMqBroker.Publisher;
 using Lykke.RabbitMqBroker.Subscriber;
 
 namespace TestInvoke.PublishExample

--- a/src/TestInvoke/PublishExample/TestMessageSerializer.cs
+++ b/src/TestInvoke/PublishExample/TestMessageSerializer.cs
@@ -1,4 +1,7 @@
-﻿using System.Text;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Text;
 using Lykke.RabbitMqBroker.Publisher;
 
 namespace TestInvoke.PublishExample

--- a/src/TestInvoke/SubscribeExample/HowToSubscribe.cs
+++ b/src/TestInvoke/SubscribeExample/HowToSubscribe.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Threading.Tasks;
 using Common.Log;
 using Lykke.RabbitMqBroker;

--- a/src/TestInvoke/SubscribeExample/TestMessageDeserializer.cs
+++ b/src/TestInvoke/SubscribeExample/TestMessageDeserializer.cs
@@ -1,4 +1,7 @@
-﻿using System.Text;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Text;
 using Lykke.RabbitMqBroker.Subscriber;
 
 namespace TestInvoke.SubscribeExample

--- a/tests/Lykke.RabbitMqBroker.Tests/AsyncPublisherTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/AsyncPublisherTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Threading;
 using System.Threading.Tasks;
 using Common;
 using Lykke.Logs;

--- a/tests/Lykke.RabbitMqBroker.Tests/Deduplication/InMemoryDeduplcatorTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/Deduplication/InMemoryDeduplcatorTest.cs
@@ -1,4 +1,7 @@
-﻿using Lykke.RabbitMqBroker.Deduplication;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using Lykke.RabbitMqBroker.Deduplication;
 using NUnit.Framework;
 
 namespace Lykke.RabbitMqBroker.Tests.Deduplication

--- a/tests/Lykke.RabbitMqBroker.Tests/DefaultErrorHandlingStrategyTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/DefaultErrorHandlingStrategyTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Threading;
 using Lykke.Logs;
 using Lykke.RabbitMqBroker;

--- a/tests/Lykke.RabbitMqBroker.Tests/PublisherConfigurationTests.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/PublisherConfigurationTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using Lykke.Logs;
 using Lykke.RabbitMqBroker.Publisher;
 using Lykke.RabbitMqBroker.Subscriber;

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitManagmentClientTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitManagmentClientTest.cs
@@ -1,4 +1,7 @@
-﻿using Newtonsoft.Json;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace RabbitMqBrokerTests

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqClusterSubsriberTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqClusterSubsriberTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqPublisherSubscriberBaseTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqPublisherSubscriberBaseTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Lykke.RabbitMqBroker.Publisher;

--- a/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubsriberTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/RabbitMqSubsriberTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/tests/Lykke.RabbitMqBroker.Tests/ResilientErrorHandlingStrategyTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/ResilientErrorHandlingStrategyTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Threading;
 using Lykke.Logs;
 using Lykke.RabbitMqBroker;

--- a/tests/Lykke.RabbitMqBroker.Tests/SyncPublisherTest.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/SyncPublisherTest.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
 using Common;
 using Lykke.Logs;
 using Lykke.RabbitMqBroker.Publisher;

--- a/tests/Lykke.RabbitMqBroker.Tests/Utils/IRabbitManagementClient.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/Utils/IRabbitManagementClient.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
 
 namespace RabbitMqBrokerTests
 {

--- a/tests/Lykke.RabbitMqBroker.Tests/Utils/RabbitManagementClient.cs
+++ b/tests/Lykke.RabbitMqBroker.Tests/Utils/RabbitManagementClient.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Lykke Corp.
+// Licensed under the MIT License. See the LICENSE file in the project root for more information.
+
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;


### PR DESCRIPTION
This repository doesn't have a license. As far as I am aware Lykke repositories should be licensed under the MIT license so that is what I'm adding in this PR. I have also included license headers following advice found here: https://softwareengineering.stackexchange.com/questions/317041/should-i-add-the-license-in-every-header-and-source-file
If there are plans for future developments of this codebase, it might makes sense to include StyleCop analyzers which would facilitate seamless addition of license headers to new source files. I'm happy to include that change in this PR if the maintainers of this repo would be keen on that.